### PR TITLE
Fix CONVEX_MESH_AND_TRIANGLE_MESH aloc import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Glacier 2 Engine Tools",
     "description": "Tools for the Glacier 2 Engine",
-    "version": (0, 7, 0),
+    "version": (0, 7, 1),
     "blender": (3, 0, 0),
     "doc_url": "https://glaciermodding.org/docs/blender/",
     "tracker_url": "https://github.com/glacier-modding/io_scene_glacier/issues",

--- a/file_aloc/bl_import_aloc.py
+++ b/file_aloc/bl_import_aloc.py
@@ -281,6 +281,7 @@ def load_aloc(operator, context, filepath, include_non_collidable_layers):
     collection.prim_collection_properties.physics_collision_type = str(PhysicsCollisionType(aloc.collision_type))
     if aloc.data_type == aloc_format.PhysicsDataType.CONVEX_MESH_AND_TRIANGLE_MESH:
         log("DEBUG", "Converting Convex Mesh and Triangle Mesh ALOC " + aloc_name + " to blender mesh", "load_aloc")
+        load_convex_mesh_objects(aloc, aloc_name, collection, context, include_non_collidable_layers)
         load_triangle_mesh_objects(aloc, aloc_name, collection, context, include_non_collidable_layers)
     elif aloc.data_type == aloc_format.PhysicsDataType.CONVEX_MESH:
         log("DEBUG", "Converting Convex Mesh ALOC " + aloc_name + " to blender mesh", "load_aloc")


### PR DESCRIPTION
This PR fixes the import for ALOCs with a data type of CONVEX_MESH_AND_TRIANGLE_MESH.